### PR TITLE
Moving all influencers to a separate tab

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,300,600&subset=latin,latin-ext);
+@import url(//fonts.googleapis.com/css?family=Open+Sans:400,300,600&subset=latin,latin-ext);
 
 body {
 	font-size: 16px;

--- a/css/main.css
+++ b/css/main.css
@@ -38,6 +38,10 @@ a {
 	top: 0;
 }
 
+.nav-tabs {
+	margin-bottom: 15px;
+}
+
 .columned h2 {
 	margin: 0 0 5px 0;
 	font-size: 16px;

--- a/css/main.css
+++ b/css/main.css
@@ -5,6 +5,7 @@ body {
 	font-family: Open Sans;
 	font-weight: 300;
 	line-height: 40px;
+	padding-bottom: 20px;
 }
 
 .past-event {
@@ -29,6 +30,12 @@ a {
 .jumbotron h1 {
 	color: #1485CC;
 	font-weight: 300;
+}
+
+.jumbotron .fork-me {
+	position: absolute;
+	right: 0;
+	top: 0;
 }
 
 .columned h2 {

--- a/index.html
+++ b/index.html
@@ -28,6 +28,13 @@
           </div>
         </div>
 
+        <div class="container">
+          <ul class="nav nav-tabs">
+            <li class="active"><a href="#home" data-toggle="tab">Home</a></li>
+            <li><a href="#influencers" data-toggle="tab">Influencers</a></li>
+          </ul>
+        </div>
+
         <div class="container tab-content">
           <div class="tab-pane active" id="home">
           <div class="columned">

--- a/index.html
+++ b/index.html
@@ -135,28 +135,28 @@
           <div>
             <h2><span class="fa fa-user"></span> Influencers</h2>
             <ul>
-              <li><a href="http://erbetowski.pl">Wojtek Erbetowski</a></li>
+              <li><a href="http://blog.kurasinski.com/">Artur Kurasiński</a> <a href="https://twitter.com/kurasinski"><i class="fa fa-twitter"></i></a></li>
+              <li>Barbara Pietraszewska</li>
+              <li><a href="http://borys.musielak.eu/">Borys Musielak</a> <a href="https://twitter.com/michuk"><i class="fa fa-twitter"></i></a></li>
+              <li>Dariusz Kaczyński <a href="https://twitter.com/dkaczynski"><i class="fa fa-twitter"></i></a></li>
+              <li><a href="http://solidcraft.eu">Jakub Nabrdalik</a></li>
               <li>Jarek Potiuk</li>
-              <li><a href="http://sitarska.com/">Ola Sitarska</a> <a href="https://twitter.com/olasitarska"><i class="fa fa-twitter"></i></a></li>
-              <li>Przemysław Lewandowski</li>
+              <li><a href="https://github.com/kamilszymanski">Kamil Szymański</a> <a href="https://twitter.com/kszdev"><i class="fa fa-twitter"></i></a></li>
               <li><a href="https://twitter.com/konradhalas/">Konrad Hałas</a></li>
               <li>Krzysztof Siejkowski</li>
-              <li>Michał Lewandowski</li>
-              <li><a href="http://leafnode.pl/">Leszek Krupiński</a> <a href="https://twitter.com/leafnode/"><i class="fa fa-twitter"></i></a></li>
-              <li><a href="http://blog.kurasinski.com/">Artur Kurasiński</a> <a href="https://twitter.com/kurasinski"><i class="fa fa-twitter"></i></a></li>
-              <li><a href="https://twitter.com/mchyzynska">Magdalena Ostoja-Chyżyńska</a></li>
-              <li><a href="http://sawicki.nu">Maciej Sawicki</a> <a href="https://twitter.com/viroos"><i class="fa fa-twitter"></i></a></li>
-              <li>Tomasz Szymański</li>
               <li>Kuba Kucharski <a href="https://twitter.com/83TB"><i class="fa fa-twitter"></i></a></li>
-              <li>Piotr Szotkowski</li>
-              <li>Barbara Pietraszewska</li>
-              <li>Piotr Betkier</li>
-              <li><a href="http://solidcraft.eu">Jakub Nabrdalik</a></li>
-              <li><a href="https://github.com/kamilszymanski">Kamil Szymański</a> <a href="https://twitter.com/kszdev"><i class="fa fa-twitter"></i></a></li>
-              <li>Dariusz Kaczyński <a href="https://twitter.com/dkaczynski"><i class="fa fa-twitter"></i></a></li>
+              <li><a href="http://leafnode.pl/">Leszek Krupiński</a> <a href="https://twitter.com/leafnode/"><i class="fa fa-twitter"></i></a></li>
+              <li><a href="http://sawicki.nu">Maciej Sawicki</a> <a href="https://twitter.com/viroos"><i class="fa fa-twitter"></i></a></li>
+              <li><a href="https://twitter.com/mchyzynska">Magdalena Ostoja-Chyżyńska</a></li>
               <li>Marek Kirejczyk <a href="https://twitter.com/marekkirejczyk"><i class="fa fa-twitter"></i></a></li>
-              <li><a href="http://borys.musielak.eu/">Borys Musielak</a> <a href="https://twitter.com/michuk"><i class="fa fa-twitter"></i></a></li>
+              <li>Michał Lewandowski</li>
+              <li><a href="http://sitarska.com/">Ola Sitarska</a> <a href="https://twitter.com/olasitarska"><i class="fa fa-twitter"></i></a></li>
               <li><a href="http://czerski.info/">Paweł Czerski</a> <a href="https://twitter.com/czerskip"><i class="fa fa-twitter"></i></a></li>
+              <li>Piotr Betkier</li>
+              <li>Piotr Szotkowski</li>
+              <li>Przemysław Lewandowski</li>
+              <li>Tomasz Szymański</li>
+              <li><a href="http://erbetowski.pl">Wojtek Erbetowski</a></li>
               <li>...</li>
             </ul>
           </div>

--- a/index.html
+++ b/index.html
@@ -157,6 +157,8 @@
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
             ga('create','UA-49963542-1');ga('send','pageview');
         </script>
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+        <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
         <script src="js/main.js"></script>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -13,11 +13,6 @@
         <link rel="stylesheet" href="css/bootstrap.min.css">
         <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
 
-        <style>
-            body {
-                padding-bottom: 20px;
-            }
-        </style>
         <link rel="stylesheet" href="css/bootstrap-theme.min.css">
         <link rel="stylesheet" href="css/main.css">
         <script src="js/vendor/modernizr-2.6.2-respond-1.1.0.min.js"></script>
@@ -29,7 +24,7 @@
         <div class="jumbotron">
           <div class="container">
             <h1>#warsawIO <a href="https://twitter.com/search?q=%23warsawio&amp;src=typd"><i class="fa fa-twitter"></i></a></h1>
-            <a href="https://github.com/WarsawIO/warsaw.io"><img style="position: absolute; top: 0; right: 0; border: 0;" src="img/gh_ribbon_green.png" alt="Fork me on GitHub"></a>
+            <a href="https://github.com/WarsawIO/warsaw.io" class="fork-me"><img src="img/gh_ribbon_green.png" alt="Fork me on GitHub"></a>
           </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -28,7 +28,9 @@
           </div>
         </div>
 
-        <div class="container columned">
+        <div class="container tab-content">
+          <div class="tab-pane active" id="home">
+          <div class="columned">
           <div>
             <h2><span class="fa fa-calendar"></span> Meetups calendars</h2>
             <ul>
@@ -108,6 +110,22 @@
             </ul>
           </div>
           <div>
+            <h2><span class="fa fa-globe"></span> Media</h2>
+            <ul>
+              <li>...</li>
+              <li>...</li>
+              <li>...</li>
+              <li>...</li>
+            </ul>
+          </div>
+          <div class="keepblock description">
+            Here should be description of the project. Feel free to fill this space with something more than a typical jibber-jabber typed just to fill space and see how it flows through the page.
+          </div>
+          </div> <!-- .columned -->
+          </div> <!-- .tab-pane -->
+          <div class="tab-pane" id="influencers">
+          <div class="columned">
+          <div>
             <h2><span class="fa fa-user"></span> Influencers</h2>
             <ul>
               <li><a href="http://erbetowski.pl">Wojtek Erbetowski</a></li>
@@ -135,19 +153,9 @@
               <li>...</li>
             </ul>
           </div>
-          <div>
-            <h2><span class="fa fa-globe"></span> Media</h2>
-            <ul>
-              <li>...</li>
-              <li>...</li>
-              <li>...</li>
-              <li>...</li>
-            </ul>
-          </div>
-          <div class="keepblock description">
-            Here should be description of the project. Feel free to fill this space with something more than a typical jibber-jabber typed just to fill space and see how it flows through the page.
-          </div>
-        </div> <!-- /container -->
+        </div> <!-- .columned -->
+        </div> <!-- .tab-pane -->
+        </div> <!-- .container -->
 
         <script>
             (function(b,o,i,l,e,r){b.GoogleAnalyticsObject=l;b[l]||(b[l]=

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
 
         <link rel="stylesheet" href="css/bootstrap.min.css">
-        <link href="http://netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
+        <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css" rel="stylesheet">
 
         <style>
             body {


### PR DESCRIPTION
As requested, I split out the influencers from the rest of the links. Thought in our case a separate tab will be easier to maintain than a whole page, since if we're not using Jekyll, including common code snippets would be a pain.

If the content keeps growing, we might need to think of a proper CMS.

Also, since I'm moving a large chunk of code anyway, I sorted the names of influencers.
